### PR TITLE
TECHDOCS: Update version info for Maven and Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To install the Java SDK from the Central Maven repository using Maven, add the f
 <dependency>
     <groupId>com.satori</groupId>
     <artifactId>satori-rtm-sdk</artifactId>
-    <version>1.1.1</version>
+    <version>[1.1.9,)</version>
 </dependency>
 ```
 
@@ -24,7 +24,7 @@ To install the Java SDK from the Central Maven repository using Gradle, add the 
 
 ```
 dependencies {
-    compile group: 'com.satori', name: 'satori-rtm-sdk', version:'1.1.1'
+    compile group: 'com.satori', name: 'satori-rtm-sdk', version:'1.1.9+'
 }
 ```
 


### PR DESCRIPTION
Version of RTM SDK for Java in README.md is incorrect and causes builds against the Java SDK to fail. Apparently, when we pushed 1.1.9 last month, 1.1.1 fell off the end of our Maven repository. Latest version is 1.1.9, and I have updated README.md to reflect this.

Please **carefully** review the version strings for Maven and Gradle. I'm not an expert in either language. The documentation should say that version 1.1.9 or later of the SDK is required.